### PR TITLE
tmdl: add ISA-agnostic sail-property backend for formal equivalence harness

### DIFF
--- a/tmdl/src/compiler.rs
+++ b/tmdl/src/compiler.rs
@@ -14,6 +14,7 @@ use crate::error::TMDLError;
 use crate::lexer::lex;
 use crate::parser::parse;
 use crate::rustgen::generate_rust;
+use crate::sail_propertygen::generate_sail_properties;
 use crate::sema_analyze;
 use crate::smtlibgen::generate_smtlib;
 
@@ -45,11 +46,15 @@ pub enum Action {
     EmitAstJson,
     EmitRust,
     EmitSmtlib,
+    EmitSailProperty,
 }
 
 impl Action {
     fn needs_whole_program(&self) -> bool {
-        matches!(self, Action::EmitRust | Action::EmitSmtlib)
+        matches!(
+            self,
+            Action::EmitRust | Action::EmitSmtlib | Action::EmitSailProperty
+        )
     }
 }
 
@@ -171,11 +176,15 @@ impl Compiler {
     }
 
     fn compile_whole_program(&self) -> Result<(), TMDLError> {
-        if matches!(self.action, Action::EmitRust) && self.dialect.is_none() {
+        if matches!(
+            self.action,
+            Action::EmitRust | Action::EmitSmtlib | Action::EmitSailProperty
+        ) && self.dialect.is_none()
+        {
             let mut cmd = Cli::command();
             cmd.error(
                 clap::error::ErrorKind::ArgumentConflict,
-                "--dialect must be specified with --action=emit-rust",
+                "--dialect must be specified with --action requiring ISA selection",
             )
             .exit();
         }
@@ -250,6 +259,15 @@ impl Compiler {
             Action::EmitSmtlib => {
                 let writer: Box<dyn Write> = self.create_output_writer()?;
                 generate_smtlib(
+                    self.dialect.as_ref().unwrap(),
+                    &parsed_files,
+                    &item_cache,
+                    writer,
+                )?;
+            }
+            Action::EmitSailProperty => {
+                let writer: Box<dyn Write> = self.create_output_writer()?;
+                generate_sail_properties(
                     self.dialect.as_ref().unwrap(),
                     &parsed_files,
                     &item_cache,

--- a/tmdl/src/lib.rs
+++ b/tmdl/src/lib.rs
@@ -4,6 +4,7 @@ mod error;
 mod lexer;
 mod parser;
 mod rustgen;
+mod sail_propertygen;
 mod sem_expr_conv;
 mod sem_expr_state;
 mod sema;

--- a/tmdl/src/sail_propertygen.rs
+++ b/tmdl/src/sail_propertygen.rs
@@ -25,16 +25,16 @@ pub fn generate_sail_properties<'a>(
     writeln!(output, "val tmdl_decode_accepts : bits(32) -> bool")?;
     writeln!(
         output,
-        "val tmdl_step_from_encoding : bits(0) -> bits(32) -> bits(0)"
+        "val tmdl_step_from_encoding : (bits(0), bits(32)) -> bits(0)"
     )?;
     writeln!(
         output,
-        "val tmdl_step_from_name : bits(0) -> string -> bits(32) -> bits(0)"
+        "val tmdl_step_from_name : (bits(0), string, bits(32)) -> bits(0)"
     )?;
-    writeln!(output, "val tmdl_state_equiv : bits(0) -> bits(0) -> bool")?;
+    writeln!(output, "val tmdl_state_equiv : (bits(0), bits(0)) -> bool")?;
     writeln!(
         output,
-        "val tmdl_reg_update_equiv : bits(0) -> bits(0) -> bits(0) -> string -> int -> bool"
+        "val tmdl_reg_update_equiv : (bits(0), bits(0), bits(0), string, int) -> bool"
     )?;
 
     for inst in files.iter().flat_map(|f| f.instructions()) {
@@ -68,7 +68,7 @@ fn emit_instruction_properties<'a>(
 
     writeln!(
         output,
-        "$property tmdl_prop_{dialect}_{name}_state_equiv\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name(pre, \"{name}\", enc);\n    let post_sail = tmdl_step_from_encoding(pre, enc);\n    tmdl_state_equiv(post_tmdl, post_sail)"
+        "$property tmdl_prop_{dialect}_{name}_state_equiv\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name((pre, \"{name}\", enc));\n    let post_sail = tmdl_step_from_encoding((pre, enc));\n    tmdl_state_equiv((post_tmdl, post_sail))"
     )?;
 
     let updated_regs = collect_updated_register_operands(instruction, &operands);
@@ -76,7 +76,7 @@ fn emit_instruction_properties<'a>(
         let class_name = register_class_name(&ty);
         writeln!(
             output,
-            "$property tmdl_prop_{dialect}_{name}_reg_{op_name}_equiv\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name(pre, \"{name}\", enc);\n    let post_sail = tmdl_step_from_encoding(pre, enc);\n    tmdl_reg_update_equiv(pre, post_tmdl, post_sail, \"{class_name}\", int({op_name}))"
+            "$property tmdl_prop_{dialect}_{name}_reg_{op_name}_equiv\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name((pre, \"{name}\", enc));\n    let post_sail = tmdl_step_from_encoding((pre, enc));\n    tmdl_reg_update_equiv((pre, post_tmdl, post_sail, \"{class_name}\", int({op_name})))"
         )?;
     }
 

--- a/tmdl/src/sail_propertygen.rs
+++ b/tmdl/src/sail_propertygen.rs
@@ -53,7 +53,6 @@ fn emit_instruction_properties<'a>(
 ) -> Result<(), TMDLError> {
     let name = instruction.name.to_lowercase();
     let operands = resolve_operands_for_instruction(instruction, item_cache);
-    let quant_sig = sail_quantified_operands(&operands);
     let encode_ty_sig = sail_encode_type_signature(&operands);
     let operand_call = sail_operand_call_list(&operands);
     let encoding_expr = format!("tmdl_encode_{dialect}_{name}{operand_call}");
@@ -61,42 +60,80 @@ fn emit_instruction_properties<'a>(
     writeln!(output, "\n/* ---- {dialect}.{name} ---- */")?;
     writeln!(output, "val tmdl_encode_{dialect}_{name} : {encode_ty_sig}")?;
 
-    writeln!(
+    emit_property_decl_and_def(
         output,
-        "$property tmdl_prop_{dialect}_{name}_encoding_valid =\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    tmdl_decode_accepts(enc)"
+        &format!("tmdl_prop_{dialect}_{name}_encoding_valid"),
+        &operands,
+        &format!("let enc = {encoding_expr};\n    tmdl_decode_accepts(enc)"),
     )?;
 
-    writeln!(
+    emit_property_decl_and_def(
         output,
-        "$property tmdl_prop_{dialect}_{name}_state_equiv =\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name((pre, \"{name}\", enc));\n    let post_sail = tmdl_step_from_encoding((pre, enc));\n    tmdl_state_equiv((post_tmdl, post_sail))"
+        &format!("tmdl_prop_{dialect}_{name}_state_equiv"),
+        &operands,
+        &format!(
+            "let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name((pre, \"{name}\", enc));\n    let post_sail = tmdl_step_from_encoding((pre, enc));\n    tmdl_state_equiv((post_tmdl, post_sail))"
+        ),
     )?;
 
     let updated_regs = collect_updated_register_operands(instruction, &operands);
     for (op_name, ty) in updated_regs {
         let class_name = register_class_name(&ty);
-        writeln!(
+        emit_property_decl_and_def(
             output,
-            "$property tmdl_prop_{dialect}_{name}_reg_{op_name}_equiv =\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name((pre, \"{name}\", enc));\n    let post_sail = tmdl_step_from_encoding((pre, enc));\n    tmdl_reg_update_equiv((pre, post_tmdl, post_sail, \"{class_name}\", int({op_name})))"
+            &format!("tmdl_prop_{dialect}_{name}_reg_{op_name}_equiv"),
+            &operands,
+            &format!(
+                "let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name((pre, \"{name}\", enc));\n    let post_sail = tmdl_step_from_encoding((pre, enc));\n    tmdl_reg_update_equiv((pre, post_tmdl, post_sail, \"{class_name}\", int({op_name})))"
+            ),
         )?;
     }
 
     Ok(())
 }
 
-fn sail_quantified_operands(operands: &[(String, Type)]) -> String {
-    let mut parts = Vec::with_capacity(operands.len());
-    for (name, ty) in operands {
-        parts.push(format!(
-            "{} : {}",
-            name.to_lowercase(),
-            sail_ty_of_operand(ty)
-        ));
-    }
+fn emit_property_decl_and_def(
+    output: &mut Box<dyn Write>,
+    property_name: &str,
+    operands: &[(String, Type)],
+    body_expr: &str,
+) -> Result<(), TMDLError> {
+    let prop_ty = sail_property_type_signature(operands);
+    let params = sail_property_function_params(operands);
 
-    if parts.is_empty() {
-        String::new()
+    writeln!(output, "$property")?;
+    writeln!(output, "val {property_name} : {prop_ty}")?;
+    writeln!(
+        output,
+        "function {property_name} {params} = {{\n    {body_expr}\n}}"
+    )?;
+
+    Ok(())
+}
+
+fn sail_property_type_signature(operands: &[(String, Type)]) -> String {
+    if operands.is_empty() {
+        "bits(0) -> bool".to_string()
     } else {
-        format!("{}, ", parts.join(", "))
+        let mut args = operands
+            .iter()
+            .map(|(_, ty)| sail_ty_of_operand(ty))
+            .collect::<Vec<_>>();
+        args.push("bits(0)");
+        format!("({}) -> bool", args.join(", "))
+    }
+}
+
+fn sail_property_function_params(operands: &[(String, Type)]) -> String {
+    if operands.is_empty() {
+        "pre".to_string()
+    } else {
+        let mut args = operands
+            .iter()
+            .map(|(name, _)| name.to_lowercase())
+            .collect::<Vec<_>>();
+        args.push("pre".to_string());
+        format!("({})", args.join(", "))
     }
 }
 

--- a/tmdl/src/sail_propertygen.rs
+++ b/tmdl/src/sail_propertygen.rs
@@ -108,8 +108,8 @@ fn sail_encode_type_signature(operands: &[(String, Type)]) -> String {
             .iter()
             .map(|(_, ty)| sail_ty_of_operand(ty))
             .collect::<Vec<_>>()
-            .join(" -> ");
-        format!("{args} -> bits(32)")
+            .join(", ");
+        format!("({args}) -> bits(32)")
     }
 }
 

--- a/tmdl/src/sail_propertygen.rs
+++ b/tmdl/src/sail_propertygen.rs
@@ -63,12 +63,12 @@ fn emit_instruction_properties<'a>(
 
     writeln!(
         output,
-        "$property tmdl_prop_{dialect}_{name}_encoding_valid\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    tmdl_decode_accepts(enc)"
+        "$property tmdl_prop_{dialect}_{name}_encoding_valid =\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    tmdl_decode_accepts(enc)"
     )?;
 
     writeln!(
         output,
-        "$property tmdl_prop_{dialect}_{name}_state_equiv\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name((pre, \"{name}\", enc));\n    let post_sail = tmdl_step_from_encoding((pre, enc));\n    tmdl_state_equiv((post_tmdl, post_sail))"
+        "$property tmdl_prop_{dialect}_{name}_state_equiv =\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name((pre, \"{name}\", enc));\n    let post_sail = tmdl_step_from_encoding((pre, enc));\n    tmdl_state_equiv((post_tmdl, post_sail))"
     )?;
 
     let updated_regs = collect_updated_register_operands(instruction, &operands);
@@ -76,7 +76,7 @@ fn emit_instruction_properties<'a>(
         let class_name = register_class_name(&ty);
         writeln!(
             output,
-            "$property tmdl_prop_{dialect}_{name}_reg_{op_name}_equiv\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name((pre, \"{name}\", enc));\n    let post_sail = tmdl_step_from_encoding((pre, enc));\n    tmdl_reg_update_equiv((pre, post_tmdl, post_sail, \"{class_name}\", int({op_name})))"
+            "$property tmdl_prop_{dialect}_{name}_reg_{op_name}_equiv =\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name((pre, \"{name}\", enc));\n    let post_sail = tmdl_step_from_encoding((pre, enc));\n    tmdl_reg_update_equiv((pre, post_tmdl, post_sail, \"{class_name}\", int({op_name})))"
         )?;
     }
 
@@ -122,7 +122,7 @@ fn sail_operand_call_list(operands: &[(String, Type)]) -> String {
             .map(|(name, _)| name.to_lowercase())
             .collect::<Vec<_>>()
             .join(", ");
-        format!("({args})")
+        format!("(({args}))")
     }
 }
 

--- a/tmdl/src/sail_propertygen.rs
+++ b/tmdl/src/sail_propertygen.rs
@@ -72,7 +72,7 @@ fn emit_instruction_properties<'a>(
         &format!("tmdl_prop_{dialect}_{name}_state_equiv"),
         &operands,
         &format!(
-            "let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name((pre, \"{name}\", enc));\n    let post_sail = tmdl_step_from_encoding((pre, enc));\n    tmdl_state_equiv((post_tmdl, post_sail))"
+            "let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name(pre, \"{name}\", enc);\n    let post_sail = tmdl_step_from_encoding(pre, enc);\n    tmdl_state_equiv(post_tmdl, post_sail)"
         ),
     )?;
 
@@ -84,7 +84,7 @@ fn emit_instruction_properties<'a>(
             &format!("tmdl_prop_{dialect}_{name}_reg_{op_name}_equiv"),
             &operands,
             &format!(
-                "let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name((pre, \"{name}\", enc));\n    let post_sail = tmdl_step_from_encoding((pre, enc));\n    tmdl_reg_update_equiv((pre, post_tmdl, post_sail, \"{class_name}\", int({op_name})))"
+                "let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name(pre, \"{name}\", enc);\n    let post_sail = tmdl_step_from_encoding(pre, enc);\n    tmdl_reg_update_equiv(pre, post_tmdl, post_sail, \"{class_name}\", int({op_name}))"
             ),
         )?;
     }
@@ -159,7 +159,7 @@ fn sail_operand_call_list(operands: &[(String, Type)]) -> String {
             .map(|(name, _)| name.to_lowercase())
             .collect::<Vec<_>>()
             .join(", ");
-        format!("(({args}))")
+        format!("({args})")
     }
 }
 

--- a/tmdl/src/sail_propertygen.rs
+++ b/tmdl/src/sail_propertygen.rs
@@ -1,0 +1,184 @@
+use std::collections::{BTreeSet, HashMap};
+use std::io::Write;
+
+use crate::Type;
+use crate::ast;
+use crate::error::TMDLError;
+use crate::utils::resolve_operands_for_instruction;
+
+pub fn generate_sail_properties<'a>(
+    dialect: &str,
+    files: &'a [ast::File],
+    item_cache: &HashMap<&'a str, &'a ast::Item>,
+    mut output: Box<dyn Write>,
+) -> Result<(), TMDLError> {
+    writeln!(
+        output,
+        "$ifndef TMDL_SAIL_PROPERTY_GENERATED\n$define TMDL_SAIL_PROPERTY_GENERATED\n\n/*\n * Auto-generated Sail property harness from TMDL.\n *\n * This file is ISA-agnostic: it only refers to instruction metadata and\n * behavior captured in TMDL. A concrete Sail model should provide the\n * hook functions declared below to map model state to the TMDL view.\n */"
+    )?;
+
+    writeln!(
+        output,
+        "\n/* ----- Integration hooks supplied by the target Sail model ----- */"
+    )?;
+    writeln!(output, "val tmdl_state_snapshot : unit -> bits(0)")?;
+    writeln!(output, "val tmdl_decode_accepts : bits(32) -> bool")?;
+    writeln!(
+        output,
+        "val tmdl_step_from_encoding : bits(0) -> bits(32) -> bits(0)"
+    )?;
+    writeln!(
+        output,
+        "val tmdl_step_from_name : bits(0) -> string -> bits(32) -> bits(0)"
+    )?;
+    writeln!(output, "val tmdl_state_equiv : bits(0) -> bits(0) -> bool")?;
+    writeln!(
+        output,
+        "val tmdl_reg_update_equiv : bits(0) -> bits(0) -> bits(0) -> string -> int -> bool"
+    )?;
+
+    for inst in files.iter().flat_map(|f| f.instructions()) {
+        emit_instruction_properties(dialect, inst, item_cache, &mut output)?;
+    }
+
+    writeln!(output, "\n$endif /* TMDL_SAIL_PROPERTY_GENERATED */")?;
+    Ok(())
+}
+
+fn emit_instruction_properties<'a>(
+    dialect: &str,
+    instruction: &'a ast::Instruction,
+    item_cache: &HashMap<&'a str, &'a ast::Item>,
+    output: &mut Box<dyn Write>,
+) -> Result<(), TMDLError> {
+    let name = instruction.name.to_lowercase();
+    let operands = resolve_operands_for_instruction(instruction, item_cache);
+    let quant_sig = sail_quantified_operands(&operands);
+    let encode_ty_sig = sail_encode_type_signature(&operands);
+    let operand_call = sail_operand_call_list(&operands);
+    let encoding_expr = format!("tmdl_encode_{dialect}_{name}{operand_call}");
+
+    writeln!(output, "\n/* ---- {dialect}.{name} ---- */")?;
+    writeln!(output, "val tmdl_encode_{dialect}_{name} : {encode_ty_sig}")?;
+
+    writeln!(
+        output,
+        "$property tmdl_prop_{dialect}_{name}_encoding_valid\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    tmdl_decode_accepts(enc)"
+    )?;
+
+    writeln!(
+        output,
+        "$property tmdl_prop_{dialect}_{name}_state_equiv\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name(pre, \"{name}\", enc);\n    let post_sail = tmdl_step_from_encoding(pre, enc);\n    tmdl_state_equiv(post_tmdl, post_sail)"
+    )?;
+
+    let updated_regs = collect_updated_register_operands(instruction, &operands);
+    for (op_name, ty) in updated_regs {
+        let class_name = register_class_name(&ty);
+        writeln!(
+            output,
+            "$property tmdl_prop_{dialect}_{name}_reg_{op_name}_equiv\n  forall ({quant_sig}pre : bits(0)).\n    let enc = {encoding_expr};\n    let post_tmdl = tmdl_step_from_name(pre, \"{name}\", enc);\n    let post_sail = tmdl_step_from_encoding(pre, enc);\n    tmdl_reg_update_equiv(pre, post_tmdl, post_sail, \"{class_name}\", int({op_name}))"
+        )?;
+    }
+
+    Ok(())
+}
+
+fn sail_quantified_operands(operands: &[(String, Type)]) -> String {
+    let mut parts = Vec::with_capacity(operands.len());
+    for (name, ty) in operands {
+        parts.push(format!(
+            "{} : {}",
+            name.to_lowercase(),
+            sail_ty_of_operand(ty)
+        ));
+    }
+
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!("{}, ", parts.join(", "))
+    }
+}
+
+fn sail_encode_type_signature(operands: &[(String, Type)]) -> String {
+    if operands.is_empty() {
+        "bits(32)".to_string()
+    } else {
+        let args = operands
+            .iter()
+            .map(|(_, ty)| sail_ty_of_operand(ty))
+            .collect::<Vec<_>>()
+            .join(" -> ");
+        format!("{args} -> bits(32)")
+    }
+}
+
+fn sail_operand_call_list(operands: &[(String, Type)]) -> String {
+    if operands.is_empty() {
+        String::new()
+    } else {
+        let args = operands
+            .iter()
+            .map(|(name, _)| name.to_lowercase())
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("({args})")
+    }
+}
+
+fn sail_ty_of_operand(ty: &Type) -> &'static str {
+    match ty {
+        Type::Struct(_) => "int",
+        Type::Bits(_) | Type::Integer => "bits(64)",
+        Type::String => "string",
+        _ => "int",
+    }
+}
+
+fn register_class_name(ty: &Type) -> String {
+    match ty {
+        Type::Struct(name) => name.clone(),
+        _ => "unknown".to_string(),
+    }
+}
+
+fn collect_updated_register_operands(
+    instruction: &ast::Instruction,
+    operands: &[(String, Type)],
+) -> Vec<(String, Type)> {
+    let reg_operands = operands
+        .iter()
+        .filter_map(|(name, ty)| match ty {
+            Type::Struct(_) => Some((name.clone(), ty.clone())),
+            _ => None,
+        })
+        .collect::<HashMap<_, _>>();
+
+    let mut written = BTreeSet::new();
+    collect_assigned_idents(&instruction.behavior, &mut written);
+
+    written
+        .into_iter()
+        .filter_map(|name| reg_operands.get(&name).cloned().map(|ty| (name, ty)))
+        .collect()
+}
+
+fn collect_assigned_idents(expr: &ast::Expr, into: &mut BTreeSet<String>) {
+    match expr {
+        ast::Expr::Assign(assign) => {
+            into.insert(assign.dest.clone());
+        }
+        ast::Expr::Block(block) => {
+            for stmt in &block.stmts {
+                collect_assigned_idents(stmt, into);
+            }
+        }
+        ast::Expr::If(if_expr) => {
+            collect_assigned_idents(&if_expr.then, into);
+            if let Some(else_expr) = &if_expr.else_ {
+                collect_assigned_idents(else_expr, into);
+            }
+        }
+        _ => {}
+    }
+}

--- a/tmdl/src/smtlibgen.rs
+++ b/tmdl/src/smtlibgen.rs
@@ -161,9 +161,7 @@ fn build_instructions<'a>(
         // pattern binding, so they are unaffected by this renaming.
         let variant_operands = operands
             .iter()
-            .map(|(op_name, ty)| {
-                format!("({}_{} {})", name, op_name.to_lowercase(), smt_ty_of(ty))
-            })
+            .map(|(op_name, ty)| format!("({}_{} {})", name, op_name.to_lowercase(), smt_ty_of(ty)))
             .collect::<Vec<_>>()
             .join(" ");
 
@@ -183,9 +181,7 @@ fn build_instructions<'a>(
             .join(" ");
 
         if operand_list.is_empty() {
-            encode_arms.push(format!(
-                "((_ is {uppercase_name}) instr) (encode_{name})"
-            ));
+            encode_arms.push(format!("((_ is {uppercase_name}) instr) (encode_{name})"));
             execute_arms.push(format!(
                 "((_ is {uppercase_name}) instr) (execute_{name} state)"
             ));
@@ -556,10 +552,12 @@ fn build_decoder<'a>(
                     let name = &id.name;
                     if operands.contains_key(name) {
                         // The entire word field holds bits [0..word_width-1] of the operand.
-                        operand_pieces
-                            .entry(name.clone())
-                            .or_default()
-                            .push((0, word_width - 1, word_lo, word_hi));
+                        operand_pieces.entry(name.clone()).or_default().push((
+                            0,
+                            word_width - 1,
+                            word_lo,
+                            word_hi,
+                        ));
                     } else if let Some((_, Some(ast::Expr::Lit(ast::Lit::Int(li))))) =
                         params.get(name)
                     {


### PR DESCRIPTION
### Motivation
- Provide a Sail `$property`-based formal verification harness that is ISA-agnostic and driven solely by TMDL instruction metadata and behavior. 
- Enable proving equivalence between the TMDL semantics and any Sail golden model (e.g. `sail-riscv`) without embedding ISA specifics outside `.tmdl` sources.

### Description
- Add a new whole-program compiler action `EmitSailProperty` and require `--dialect` for actions that need ISA selection by extending `tmdl/src/compiler.rs` and registering the action in the CLI as `emit-sail-property`.
- Introduce `tmdl/src/sail_propertygen.rs` which implements `generate_sail_properties` to emit Sail scaffolding and `$property` checks per instruction, including abstract integration hooks (`tmdl_state_snapshot`, `tmdl_decode_accepts`, `tmdl_step_from_encoding`, `tmdl_step_from_name`, `tmdl_state_equiv`, `tmdl_reg_update_equiv`).
- For each instruction the generator emits:
  - an `tmdl_encode_<dialect>_<instr>` declaration with a suitable Sail type signature, 
  - an encoding-validity property asserting `tmdl_decode_accepts(enc)`, 
  - a post-state equivalence property asserting `tmdl_state_equiv(post_tmdl, post_sail)`, and
  - per-written-register equivalence properties derived by analyzing assigned identifiers in the TMDL `behavior`.
- Register the new module in `tmdl/src/lib.rs` and make small formatting/cleanup edits in `tmdl/src/smtlibgen.rs` (no semantic changes) to keep formatting consistent.

### Testing
- Ran `cargo fmt --all` to normalize formatting and it completed successfully.
- Ran unit tests with `cargo test -p tmdl` and all TMDL tests passed (`8 passed; 0 failed`).
- Exercised the new backend end-to-end with `cargo run -p tmdl -- --action emit-sail-property --dialect RV64I --output /tmp/rv64_props.sail backends/riscv/defs/main.tmdl backends/riscv/defs/base.tmdl` and verified the generated `/tmp/rv64_props.sail` contains the expected harness and per-instruction properties (generation completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699993b6d1908328a4113261878eb41a)