### PR TITLE
feat: compile a simple C function to IR via a new ptr dialect

### DIFF
--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -15,6 +15,7 @@ use crate::{
         ImplementsOpInterface, OpInterfaceConverter, downcast_op_interface, op_interface_converter,
     },
     parse::{Span, text::Parser as IRParser},
+    ptr::PtrDialect,
     region::RegionId,
     ty::{Type, TypeParser},
     value::{Value, ValueId},
@@ -114,6 +115,7 @@ impl Context {
         let context = Context::new();
 
         context.register_dialect::<BuiltinDialect>();
+        context.register_dialect::<PtrDialect>();
 
         context
     }
@@ -601,7 +603,12 @@ mod tests {
             .collect();
         indices.sort();
         assert_eq!(indices, vec![0, 1]);
-        assert!(context.value_uses(x.id()).iter().all(|u| u.op() == add.id()));
+        assert!(
+            context
+                .value_uses(x.id())
+                .iter()
+                .all(|u| u.op() == add.id())
+        );
     }
 
     #[test]

--- a/core/src/dialects/mod.rs
+++ b/core/src/dialects/mod.rs
@@ -1,1 +1,2 @@
 pub mod builtin;
+pub mod ptr;

--- a/core/src/dialects/ptr/mod.rs
+++ b/core/src/dialects/ptr/mod.rs
@@ -1,0 +1,224 @@
+//! The `ptr` dialect: pointers plus the loads and stores that read and write
+//! through them. It is deliberately tiny — just enough to express the
+//! memory-based (non-SSA) lowering a simple C frontend produces, where every
+//! local lives in a stack slot. There is no pointer arithmetic and loads/stores
+//! carry no offset.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use crate::ty::TypeConstraint;
+use crate::{Context, Error, IRFormatter, Type, TypeId, dialect, operation, parse::Span};
+
+use crate as tir;
+use crate::Any as AnyConstraint;
+
+pub mod ops {
+    pub use super::{AllocaOp, LoadOp, StoreOp, alloca, load, store};
+}
+
+dialect! {
+    PtrDialect {
+        name: "ptr",
+        operations: [
+            AllocaOp,
+            LoadOp,
+            StoreOp,
+        ],
+        types: [PtrType],
+    }
+}
+
+/// A pointer type, written `!ptr.p` (opaque) or `!ptr.p<!i32>` (typed). A typed
+/// pointer remembers its pointee so loads can recover their result type; an
+/// opaque pointer carries no pointee.
+pub struct PtrType {
+    pointee: Option<Arc<dyn Type>>,
+}
+
+impl PtrType {
+    /// An opaque pointer: `!ptr.p`.
+    pub fn opaque(context: &Context) -> TypeId {
+        context.get_type_id(Arc::new(Self { pointee: None }))
+    }
+
+    /// A typed pointer to `pointee`: `!ptr.p<!pointee>`.
+    pub fn typed(context: &Context, pointee: TypeId) -> TypeId {
+        let pointee = context.get_type_data(pointee);
+        context.get_type_id(Arc::new(Self {
+            pointee: Some(pointee),
+        }))
+    }
+
+    /// The pointee type id, or `None` for an opaque pointer.
+    pub fn pointee(&self, context: &Context) -> Option<TypeId> {
+        self.pointee
+            .as_ref()
+            .map(|p| context.get_type_id(p.clone()))
+    }
+}
+
+impl TypeConstraint for PtrType {}
+
+impl Type for PtrType {
+    fn dialect(&self) -> &'static str {
+        "ptr"
+    }
+
+    fn parse_key() -> &'static str {
+        "p"
+    }
+
+    fn parse<'src>(
+        _mnemonic: &str,
+        parser: &mut tir::parse::text::Parser<'src>,
+        context: &Context,
+    ) -> Result<TypeId, (Span, Error)> {
+        use tir::parse::common::Cursor;
+        if parser.parse_token("<") {
+            let pointee = parser
+                .parse_type(context)?
+                .ok_or_else(|| (parser.span(), Error::ExpectedType))?;
+            if !parser.parse_token(">") {
+                return Err((parser.span(), Error::ExpectedToken(">")));
+            }
+            Ok(Self::typed(context, pointee))
+        } else {
+            Ok(Self::opaque(context))
+        }
+    }
+
+    fn print(&self, fmt: &mut IRFormatter<'_>) -> Result<(), std::fmt::Error> {
+        fmt.write("p")?;
+        if let Some(pointee) = &self.pointee {
+            fmt.write("<!")?;
+            if pointee.dialect() != "builtin" {
+                fmt.write(format!("{}.", pointee.dialect()))?;
+            }
+            pointee.print(fmt)?;
+            fmt.write(">")?;
+        }
+        Ok(())
+    }
+
+    fn eq(&self, other: &dyn Type) -> bool {
+        let Some(other) = (other as &dyn Any).downcast_ref::<PtrType>() else {
+            return false;
+        };
+        match (&self.pointee, &other.pointee) {
+            (None, None) => true,
+            (Some(a), Some(b)) => a.eq(b.as_ref()),
+            _ => false,
+        }
+    }
+}
+
+operation! {
+    AllocaOp {
+        name: "alloca",
+        dialect: "ptr",
+        results: R {
+            result: "crate::ptr::PtrType",
+        },
+    }
+}
+
+operation! {
+    LoadOp {
+        name: "load",
+        dialect: "ptr",
+        operands: O {
+            ptr: "crate::ptr::PtrType",
+        },
+        results: R {
+            result: "AnyConstraint",
+        },
+    }
+}
+
+operation! {
+    StoreOp {
+        name: "store",
+        dialect: "ptr",
+        operands: O {
+            value: "AnyConstraint",
+            ptr: "crate::ptr::PtrType",
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        IRBuilder, IRFormatter, Operation,
+        builtin::{FuncOp, IntegerType, ops as builtin_ops},
+        parse::ir::parse_ir,
+    };
+
+    #[test]
+    fn opaque_and_typed_pointer_roundtrip() {
+        let context = Context::with_default_dialects();
+
+        let opaque = PtrType::opaque(&context);
+        assert_eq!(context.type_to_string(opaque), "!ptr.p");
+
+        let i32_ty = IntegerType::new(&context, 32);
+        let typed = PtrType::typed(&context, i32_ty);
+        assert_eq!(context.type_to_string(typed), "!ptr.p<!i32>");
+
+        // Typed pointer remembers its pointee.
+        let data = context.get_type_data(typed);
+        let ptr = (data.as_ref() as &dyn Any)
+            .downcast_ref::<PtrType>()
+            .unwrap();
+        assert_eq!(ptr.pointee(&context), Some(i32_ty));
+
+        // An opaque pointer carries no pointee.
+        let opaque_data = context.get_type_data(opaque);
+        let opaque_ptr = (opaque_data.as_ref() as &dyn Any)
+            .downcast_ref::<PtrType>()
+            .unwrap();
+        assert_eq!(opaque_ptr.pointee(&context), None);
+
+        // Typed and opaque pointers are distinct, identical ones are interned.
+        assert_ne!(opaque, typed);
+        assert_eq!(PtrType::typed(&context, i32_ty), typed);
+    }
+
+    #[test]
+    fn alloca_store_load_in_func_roundtrip() {
+        let context = Context::with_default_dialects();
+        let i32_ty = IntegerType::new(&context, 32);
+
+        let param = context.create_value(i32_ty, None);
+        let param_id = param.id();
+        let region = context.create_region();
+        let block = context.create_block(vec![param]);
+        region.add_block(block.id());
+
+        let func = builtin_ops::func(&context, "id", i32_ty, Some(region.id())).build();
+
+        let mut builder = IRBuilder::new(func.body());
+        let slot = builder.insert(ops::alloca(&context, PtrType::typed(&context, i32_ty)).build());
+        builder.insert(ops::store(&context, param_id, slot.result()).build());
+        let loaded = builder.insert(ops::load(&context, slot.result(), i32_ty).build());
+        builder.insert(builtin_ops::r#return(&context, loaded.result()).build());
+
+        assert!(func.verify(&context).is_ok());
+
+        let mut buf = String::new();
+        let mut f = IRFormatter::new(&mut buf);
+        func.print(&mut f).expect("print ok");
+        assert!(buf.contains("ptr.alloca"));
+        assert!(buf.contains("ptr.store"));
+        assert!(buf.contains("ptr.load"));
+
+        let new_context = Context::with_default_dialects();
+        let new_func = parse_ir::<FuncOp>(&new_context, &buf).expect("parse func");
+        let mut new_buf = String::new();
+        let mut f = IRFormatter::new(&mut new_buf);
+        new_func.print(&mut f).expect("print ok");
+        assert_eq!(buf, new_buf);
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -47,5 +47,6 @@ pub use value::{Use, UseSite, Value, ValueId};
 
 pub use dialects::builtin;
 pub use dialects::builtin::Integer;
+pub use dialects::ptr;
 
 pub use tir_macros::{dialect, operation};

--- a/core/src/parse/ir.rs
+++ b/core/src/parse/ir.rs
@@ -32,7 +32,7 @@ pub(crate) fn parse_single_op<'src>(
     }
 
     if let Some(name) = parser.parse_ident() {
-        let (dialect, name) = if parser.peek_char() == Some('.') {
+        let (dialect, name) = if parser.parse_token(".") {
             if let Some(op_name) = parser.parse_ident() {
                 (name, op_name)
             } else {

--- a/core/src/parse/text.rs
+++ b/core/src/parse/text.rs
@@ -140,7 +140,7 @@ impl<'src> Parser<'src> {
             .parse_ident()
             .ok_or_else(|| (self.span(), crate::Error::ExpectedType))?;
 
-        let (dialect, name) = if self.peek_char() == Some('.') {
+        let (dialect, name) = if self.parse_token(".") {
             let Some(name) = self.parse_ident() else {
                 return Err((self.span(), crate::Error::ExpectedType));
             };

--- a/fcc/Cargo.toml
+++ b/fcc/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 logos = "0.16.1"
+chumsky = "0.10.1"
 tir = { path = "../core" }
 clap = { version = "4.6.0", features = ["derive"] }
 

--- a/fcc/src/ast.rs
+++ b/fcc/src/ast.rs
@@ -1,0 +1,61 @@
+//! A tiny C abstract syntax tree — only the constructs needed to drive a
+//! simple integer function (parameters, local `int` variables, arithmetic and
+//! `return`) down to IR. There are no types beyond `int`/`void`, no control
+//! flow, and no pointers at the source level.
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CType {
+    Int,
+    Void,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TranslationUnit {
+    pub functions: Vec<Function>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Function {
+    pub name: String,
+    pub ret: CType,
+    pub params: Vec<Param>,
+    pub body: Vec<Stmt>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Param {
+    pub name: String,
+    pub ty: CType,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Stmt {
+    /// `int name = init;` or `int name;`
+    Decl {
+        name: String,
+        ty: CType,
+        init: Option<Expr>,
+    },
+    /// `name = value;`
+    Assign { name: String, value: Expr },
+    /// `return expr;` or `return;`
+    Return(Option<Expr>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr {
+    Int(i64),
+    Var(String),
+    Binary {
+        op: BinOp,
+        lhs: Box<Expr>,
+        rhs: Box<Expr>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinOp {
+    Add,
+    Sub,
+    Mul,
+}

--- a/fcc/src/codegen.rs
+++ b/fcc/src/codegen.rs
@@ -1,0 +1,182 @@
+//! Lowers the C [`ast`] to TIR using the `builtin` and `ptr` dialects.
+//!
+//! The lowering is intentionally memory-based (the unoptimised, "no memory
+//! SSA" shape a C frontend emits before any mem2reg pass): every parameter and
+//! local lives in a stack slot produced by `ptr.alloca`, reads become
+//! `ptr.load` and writes become `ptr.store`. Arithmetic uses the `builtin`
+//! integer ops. Only `int` (lowered to `i32`) and `void` are supported.
+
+use std::collections::HashMap;
+
+use tir::builtin::{IntegerType, UnitType, ops as b};
+use tir::ptr::{PtrType, ops as p};
+use tir::{Context, IRBuilder, IRFormatter, Operand, Operation, TypeId, ValueId};
+
+use crate::ast::*;
+
+/// A local variable: the pointer to its stack slot and the slot's element type.
+#[derive(Clone, Copy)]
+struct Slot {
+    ptr: ValueId,
+    elem: TypeId,
+}
+
+struct FnCodegen<'a> {
+    context: &'a Context,
+    builder: IRBuilder,
+    locals: HashMap<String, Slot>,
+}
+
+/// Lower a translation unit into a `builtin.module` and return the printed IR.
+pub fn codegen(unit: &TranslationUnit) -> Result<String, String> {
+    let context = Context::with_default_dialects();
+
+    let module = b::module(&context, None).build();
+    let mut module_builder = IRBuilder::new(module.body());
+
+    for func in &unit.functions {
+        let func_op = lower_function(&context, func)?;
+        module_builder.insert(func_op);
+    }
+    module_builder.insert(b::module_end(&context).build());
+
+    let mut out = String::new();
+    let mut fmt = IRFormatter::new(&mut out);
+    module
+        .print(&mut fmt)
+        .map_err(|e| format!("failed to print IR: {e}"))?;
+    Ok(out)
+}
+
+fn lower_ctype(context: &Context, ty: &CType) -> TypeId {
+    match ty {
+        CType::Int => IntegerType::new(context, 32),
+        CType::Void => UnitType::new(context),
+    }
+}
+
+fn lower_function(context: &Context, func: &Function) -> Result<impl Operation, String> {
+    let ret_ty = lower_ctype(context, &func.ret);
+
+    // Entry block arguments carry the incoming parameter values.
+    let mut param_values = Vec::new();
+    for param in &func.params {
+        let ty = lower_ctype(context, &param.ty);
+        param_values.push(context.create_value(ty, None));
+    }
+    let param_ids: Vec<ValueId> = param_values.iter().map(|v| v.id()).collect();
+
+    let region = context.create_region();
+    let block = context.create_block(param_values);
+    region.add_block(block.id());
+
+    let func_op = b::func(context, func.name.as_str(), ret_ty, Some(region.id())).build();
+
+    let mut cg = FnCodegen {
+        context,
+        builder: IRBuilder::new(func_op.body()),
+        locals: HashMap::new(),
+    };
+
+    // Spill each parameter into its own stack slot, mirroring -O0 codegen.
+    for (param, value) in func.params.iter().zip(param_ids) {
+        let elem = lower_ctype(context, &param.ty);
+        let slot = cg.alloca(elem);
+        cg.builder
+            .insert(p::store(context, value, slot.ptr).build());
+        cg.locals.insert(param.name.clone(), slot);
+    }
+
+    for stmt in &func.body {
+        cg.lower_stmt(stmt)?;
+    }
+
+    Ok(func_op)
+}
+
+impl FnCodegen<'_> {
+    fn alloca(&mut self, elem: TypeId) -> Slot {
+        let ptr_ty = PtrType::typed(self.context, elem);
+        let op = self.builder.insert(p::alloca(self.context, ptr_ty).build());
+        Slot {
+            ptr: op.result(),
+            elem,
+        }
+    }
+
+    fn lower_stmt(&mut self, stmt: &Stmt) -> Result<(), String> {
+        match stmt {
+            Stmt::Decl { name, ty, init } => {
+                let elem = lower_ctype(self.context, ty);
+                let slot = self.alloca(elem);
+                if let Some(expr) = init {
+                    let value = self.lower_expr(expr)?;
+                    self.builder
+                        .insert(p::store(self.context, value, slot.ptr).build());
+                }
+                self.locals.insert(name.clone(), slot);
+                Ok(())
+            }
+            Stmt::Assign { name, value } => {
+                let slot = *self
+                    .locals
+                    .get(name)
+                    .ok_or_else(|| format!("assignment to unknown variable '{name}'"))?;
+                let v = self.lower_expr(value)?;
+                self.builder
+                    .insert(p::store(self.context, v, slot.ptr).build());
+                Ok(())
+            }
+            Stmt::Return(expr) => {
+                let operand = match expr {
+                    Some(e) => Operand::from(self.lower_expr(e)?),
+                    None => Operand::none(),
+                };
+                self.builder
+                    .insert(b::r#return(self.context, operand).build());
+                Ok(())
+            }
+        }
+    }
+
+    fn lower_expr(&mut self, expr: &Expr) -> Result<ValueId, String> {
+        let i32_ty = IntegerType::new(self.context, 32);
+        match expr {
+            Expr::Int(n) => {
+                let op = self
+                    .builder
+                    .insert(b::constant(self.context, *n, i32_ty).build());
+                Ok(op.result())
+            }
+            Expr::Var(name) => {
+                let slot = *self
+                    .locals
+                    .get(name)
+                    .ok_or_else(|| format!("use of unknown variable '{name}'"))?;
+                let op = self
+                    .builder
+                    .insert(p::load(self.context, slot.ptr, slot.elem).build());
+                Ok(op.result())
+            }
+            Expr::Binary { op, lhs, rhs } => {
+                let l = self.lower_expr(lhs)?;
+                let r = self.lower_expr(rhs)?;
+                let result = match op {
+                    BinOp::Add => self
+                        .builder
+                        .insert(b::addi(self.context, l, r, i32_ty).build())
+                        .result(),
+                    BinOp::Sub => self
+                        .builder
+                        .insert(b::subi(self.context, l, r, i32_ty).build())
+                        .result(),
+                    BinOp::Mul => self
+                        .builder
+                        .insert(b::muli(self.context, l, r, i32_ty).build())
+                        .result(),
+                };
+                Ok(result)
+            }
+        }
+    }
+}

--- a/fcc/src/codegen_tests.rs
+++ b/fcc/src/codegen_tests.rs
@@ -1,0 +1,65 @@
+#[cfg(test)]
+mod tests {
+    use crate::codegen::codegen;
+    use crate::parser::parse;
+    use logos::Logos;
+
+    use crate::lexer::Token;
+
+    fn compile(src: &str) -> String {
+        let tokens: Vec<Token> = Token::lexer(src).map(|r| r.unwrap()).collect();
+        let unit = parse(&tokens).expect("parse");
+        codegen(&unit).expect("codegen")
+    }
+
+    #[test]
+    fn sum_of_two_numbers() {
+        let ir = compile("int sum(int a, int b) { return a + b; }");
+
+        // The function and its memory-based parameter handling are present.
+        assert!(ir.contains("module"));
+        assert!(ir.contains("func @sum"));
+        assert!(ir.contains("ptr.alloca"));
+        assert!(ir.contains("ptr.store"));
+        assert!(ir.contains("ptr.load"));
+        assert!(ir.contains("addi"));
+        assert!(ir.contains("return"));
+        // Two parameters => two stack slots.
+        assert_eq!(ir.matches("ptr.alloca").count(), 2);
+        assert_eq!(ir.matches("ptr.store").count(), 2);
+        assert_eq!(ir.matches("ptr.load").count(), 2);
+    }
+
+    #[test]
+    fn ir_roundtrips_through_parser() {
+        // The emitted IR must parse back as a module and print identically.
+        let ir = compile("int sum(int a, int b) { return a + b; }");
+
+        let context = tir::Context::with_default_dialects();
+        let module = tir::parse::ir::parse_ir::<tir::builtin::ModuleOp>(&context, &ir)
+            .expect("emitted IR should parse back");
+
+        let mut buf = String::new();
+        let mut fmt = tir::IRFormatter::new(&mut buf);
+        tir::Operation::print(&module, &mut fmt).expect("print");
+        assert_eq!(ir, buf);
+    }
+
+    #[test]
+    fn local_variable_and_arithmetic() {
+        let ir = compile("int f(int a, int b) { int c = a * b; return c + 1; }");
+        // params a, b and local c => three slots.
+        assert_eq!(ir.matches("ptr.alloca").count(), 3);
+        assert!(ir.contains("muli"));
+        assert!(ir.contains("constant"));
+        assert!(ir.contains("addi"));
+    }
+
+    #[test]
+    fn void_function() {
+        let ir = compile("void nop(void) { return; }");
+        assert!(ir.contains("func @nop"));
+        assert!(ir.contains("return"));
+        assert_eq!(ir.matches("ptr.alloca").count(), 0);
+    }
+}

--- a/fcc/src/driver.rs
+++ b/fcc/src/driver.rs
@@ -34,6 +34,7 @@ pub struct CompileArgs {
 pub enum CompileStage {
     Preprocess,
     Ast,
+    Ir,
 }
 
 pub fn compiler_main() {
@@ -48,15 +49,13 @@ fn run_compile(args: CompileArgs) {
         Box::new(BufWriter::new(io::stdout()))
     } else {
         let path = PathBuf::from(&args.output);
-        Box::new(BufWriter::new(
-            File::create(&path).unwrap_or_else(|e| {
-                eprintln!(
-                    "fcc: cannot open output '{}': {e}",
-                    args.output.to_string_lossy()
-                );
-                std::process::exit(1);
-            }),
-        ))
+        Box::new(BufWriter::new(File::create(&path).unwrap_or_else(|e| {
+            eprintln!(
+                "fcc: cannot open output '{}': {e}",
+                args.output.to_string_lossy()
+            );
+            std::process::exit(1);
+        })))
     };
 
     for input in &args.inputs {
@@ -64,10 +63,7 @@ fn run_compile(args: CompileArgs) {
             Box::new(io::stdin())
         } else {
             Box::new(File::open(input).unwrap_or_else(|e| {
-                eprintln!(
-                    "fcc: cannot open input '{}': {e}",
-                    input.to_string_lossy()
-                );
+                eprintln!("fcc: cannot open input '{}': {e}", input.to_string_lossy());
                 std::process::exit(1);
             }))
         };
@@ -77,11 +73,31 @@ fn run_compile(args: CompileArgs) {
                 emit_preprocess(&mut out, preprocessed(reader, HashMap::new(), &[]));
             }
             CompileStage::Ast => {
-                eprintln!("fcc: AST stage not yet implemented");
-                std::process::exit(1);
+                let unit = parse_source(reader);
+                writeln!(out, "{unit:#?}").unwrap();
+            }
+            CompileStage::Ir => {
+                let unit = parse_source(reader);
+                match crate::codegen::codegen(&unit) {
+                    Ok(ir) => write!(out, "{ir}").unwrap(),
+                    Err(e) => {
+                        eprintln!("fcc: codegen error: {e}");
+                        std::process::exit(1);
+                    }
+                }
             }
         }
     }
+}
+
+fn parse_source(reader: Box<dyn io::Read>) -> crate::ast::TranslationUnit {
+    let tokens: Vec<Token> = preprocessed(reader, HashMap::new(), &[]).collect();
+    crate::parser::parse(&tokens).unwrap_or_else(|errors| {
+        for e in errors {
+            eprintln!("fcc: parse error: {e}");
+        }
+        std::process::exit(1);
+    })
 }
 
 fn emit_preprocess(out: &mut dyn Write, tokens: impl Iterator<Item = Token>) {

--- a/fcc/src/lexer.rs
+++ b/fcc/src/lexer.rs
@@ -124,6 +124,16 @@ pub enum Token {
     RBrace,
     #[token(";")]
     Semicolon,
+    #[token(",")]
+    Comma,
+    #[token("=")]
+    Assign,
+    #[token("+")]
+    Plus,
+    #[token("-")]
+    Minus,
+    #[token("*")]
+    Star,
 }
 
 impl fmt::Display for Token {
@@ -184,6 +194,11 @@ impl fmt::Display for Token {
             Token::LBrace => f.write_str("{"),
             Token::RBrace => f.write_str("}"),
             Token::Semicolon => f.write_str(";"),
+            Token::Comma => f.write_str(","),
+            Token::Assign => f.write_str("="),
+            Token::Plus => f.write_str("+"),
+            Token::Minus => f.write_str("-"),
+            Token::Star => f.write_str("*"),
         }
     }
 }

--- a/fcc/src/lib.rs
+++ b/fcc/src/lib.rs
@@ -1,7 +1,12 @@
+pub mod ast;
+pub mod codegen;
 pub mod driver;
 pub mod lexer;
+pub mod parser;
 pub mod preprocessor;
 
+#[cfg(test)]
+mod codegen_tests;
 #[cfg(test)]
 mod lexer_tests;
 #[cfg(test)]

--- a/fcc/src/parser.rs
+++ b/fcc/src/parser.rs
@@ -1,0 +1,157 @@
+//! A [`chumsky`]-based parser turning a token stream into the [`ast`], in the
+//! same style as the TMDL compiler's parser (combinators over a token slice
+//! with `Rich` errors).
+//!
+//! It accepts just enough C to express integer functions: `int`/`void` return
+//! types and parameters, local `int` declarations, assignments, simple
+//! arithmetic (`+`, `-`, `*`, parentheses) and `return`.
+
+use chumsky::input::ValueInput;
+use chumsky::prelude::*;
+
+use crate::ast::*;
+use crate::lexer::Token;
+
+/// Index-based span over the token slice (we parse already-lexed tokens, so
+/// byte offsets are not available — token indices are the natural span).
+type Span = SimpleSpan<usize>;
+type Extra<'src> = extra::Err<Rich<'src, Token, Span>>;
+
+/// Parse a token stream into a translation unit. Whitespace tokens are dropped
+/// first; on failure the collected diagnostics are returned as strings.
+pub fn parse(tokens: &[Token]) -> Result<TranslationUnit, Vec<String>> {
+    let filtered: Vec<Token> = tokens
+        .iter()
+        .filter(|t| !matches!(t, Token::Whitespace(_)))
+        .cloned()
+        .collect();
+
+    let (out, errors) = translation_unit()
+        .parse(filtered.as_slice())
+        .into_output_errors();
+
+    match out {
+        Some(unit) if errors.is_empty() => Ok(unit),
+        _ => Err(errors.into_iter().map(|e| e.to_string()).collect()),
+    }
+}
+
+fn ctype<'src, I>() -> impl Parser<'src, I, CType, Extra<'src>> + Clone
+where
+    I: ValueInput<'src, Token = Token, Span = Span>,
+{
+    select! {
+        Token::KwInt => CType::Int,
+        Token::KwVoid => CType::Void,
+    }
+}
+
+fn ident<'src, I>() -> impl Parser<'src, I, String, Extra<'src>> + Clone
+where
+    I: ValueInput<'src, Token = Token, Span = Span>,
+{
+    select! { Token::Identifier(name) => name }
+}
+
+fn expr<'src, I>() -> impl Parser<'src, I, Expr, Extra<'src>> + Clone
+where
+    I: ValueInput<'src, Token = Token, Span = Span>,
+{
+    recursive(|expr| {
+        let primary = choice((
+            select! { Token::IntegerLiteral(n) => Expr::Int(n.to_i64()) },
+            ident().map(Expr::Var),
+            expr.delimited_by(just(Token::LParen), just(Token::RParen)),
+        ));
+
+        // `*` binds tighter than `+`/`-`; both are left-associative.
+        let product = primary.clone().foldl(
+            just(Token::Star).ignore_then(primary).repeated(),
+            |lhs, rhs| Expr::Binary {
+                op: BinOp::Mul,
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
+            },
+        );
+
+        let add_op = choice((
+            just(Token::Plus).to(BinOp::Add),
+            just(Token::Minus).to(BinOp::Sub),
+        ));
+
+        product
+            .clone()
+            .foldl(add_op.then(product).repeated(), |lhs, (op, rhs)| {
+                Expr::Binary {
+                    op,
+                    lhs: Box::new(lhs),
+                    rhs: Box::new(rhs),
+                }
+            })
+    })
+}
+
+fn stmt<'src, I>() -> impl Parser<'src, I, Stmt, Extra<'src>> + Clone
+where
+    I: ValueInput<'src, Token = Token, Span = Span>,
+{
+    let ret = just(Token::KwReturn)
+        .ignore_then(expr().or_not())
+        .then_ignore(just(Token::Semicolon))
+        .map(Stmt::Return);
+
+    let decl = ctype()
+        .then(ident())
+        .then(just(Token::Assign).ignore_then(expr()).or_not())
+        .then_ignore(just(Token::Semicolon))
+        .map(|((ty, name), init)| Stmt::Decl { name, ty, init });
+
+    let assign = ident()
+        .then_ignore(just(Token::Assign))
+        .then(expr())
+        .then_ignore(just(Token::Semicolon))
+        .map(|(name, value)| Stmt::Assign { name, value });
+
+    choice((ret, decl, assign))
+}
+
+fn function<'src, I>() -> impl Parser<'src, I, Function, Extra<'src>> + Clone
+where
+    I: ValueInput<'src, Token = Token, Span = Span>,
+{
+    let param = ctype().then(ident()).map(|(ty, name)| Param { name, ty });
+
+    // `(void)` is an explicit empty parameter list; `()` is also accepted.
+    let params = choice((
+        just(Token::KwVoid).to(Vec::new()),
+        param.separated_by(just(Token::Comma)).collect::<Vec<_>>(),
+    ))
+    .delimited_by(just(Token::LParen), just(Token::RParen));
+
+    let body = stmt()
+        .repeated()
+        .collect::<Vec<_>>()
+        .delimited_by(just(Token::LBrace), just(Token::RBrace));
+
+    ctype()
+        .then(ident())
+        .then(params)
+        .then(body)
+        .map(|(((ret, name), params), body)| Function {
+            name,
+            ret,
+            params,
+            body,
+        })
+}
+
+fn translation_unit<'src, I>() -> impl Parser<'src, I, TranslationUnit, Extra<'src>>
+where
+    I: ValueInput<'src, Token = Token, Span = Span>,
+{
+    function()
+        .repeated()
+        .collect::<Vec<_>>()
+        .then_ignore(end())
+        .map(|functions| TranslationUnit { functions })
+}

--- a/fcc/src/snapshots/fcc__preprocessor_tests__tests__define_integer.snap
+++ b/fcc/src/snapshots/fcc__preprocessor_tests__tests__define_integer.snap
@@ -1,5 +1,6 @@
 ---
 source: fcc/src/preprocessor_tests.rs
+assertion_line: 41
 expression: "pp(\"#define LIMIT 42\\nint x = LIMIT;\")"
 ---
 [
@@ -13,6 +14,7 @@ expression: "pp(\"#define LIMIT 42\\nint x = LIMIT;\")"
     Whitespace(
         " ",
     ),
+    Assign,
     Whitespace(
         " ",
     ),

--- a/fcc/src/snapshots/fcc__preprocessor_tests__tests__predefined_macro.snap
+++ b/fcc/src/snapshots/fcc__preprocessor_tests__tests__predefined_macro.snap
@@ -1,5 +1,6 @@
 ---
 source: fcc/src/preprocessor_tests.rs
+assertion_line: 57
 expression: "pp_with_defines(\"int x = N;\", &[(\"N\", \"7\")])"
 ---
 [
@@ -13,6 +14,7 @@ expression: "pp_with_defines(\"int x = N;\", &[(\"N\", \"7\")])"
     Whitespace(
         " ",
     ),
+    Assign,
     Whitespace(
         " ",
     ),

--- a/fcc/src/snapshots/fcc__preprocessor_tests__tests__undef.snap
+++ b/fcc/src/snapshots/fcc__preprocessor_tests__tests__undef.snap
@@ -1,5 +1,6 @@
 ---
 source: fcc/src/preprocessor_tests.rs
+assertion_line: 64
 expression: "pp(\"#define FOO 1\\n#undef FOO\\nint x = FOO;\")"
 ---
 [
@@ -13,6 +14,7 @@ expression: "pp(\"#define FOO 1\\n#undef FOO\\nint x = FOO;\")"
     Whitespace(
         " ",
     ),
+    Assign,
     Whitespace(
         " ",
     ),


### PR DESCRIPTION
Drives a simple C function (e.g. sum of two integers) all the way to IR, building on the existing C lexer/preprocessor.

```c
int sum(int a, int b) { return a + b; }
```
```
$ fcc compile --stage ir -
module {
  func @sum(%0: !i32, %1: !i32) -> !i32 {
    %2 = ptr.alloca : !ptr.p<!i32>
    ptr.store %0, %2
    %3 = ptr.alloca : !ptr.p<!i32>
    ptr.store %1, %3
    %4 = ptr.load %2 : !i32
    %5 = ptr.load %3 : !i32
    %6 = addi %4, %5 : !i32
    return %6
  }
  module_end
}
```

## Core: new `ptr` dialect
- **`p` pointer type** — opaque `!ptr.p` and typed `!ptr.p<!i32>`. A typed pointer remembers its pointee so loads can recover their result type.
- **`alloca`, `load`, `store`** ops — no offsets and no pointer arithmetic, by design.
- Registered `PtrDialect` in `with_default_dialects`.
- **Bug fix:** dialect-prefixed op/type parsing (`ptr.load`, `!ptr.p`) never consumed the `.` separator before reading the second identifier, so any `dialect.name` form failed. This was previously unexercised because the builtin dialect uses no prefix.

## fcc frontend
- Lex `+ - * = ,`.
- A **chumsky-based parser** (same style as the TMDL compiler — combinators over a token slice with `Rich` errors) producing a small C AST: `int`/`void` functions and params, local `int` declarations, assignments, `+ - *` arithmetic and `return`.
- **Memory-based codegen** (the unoptimised, "no memory SSA" shape a frontend emits before mem2reg): every parameter and local lives in a stack slot via `ptr.alloca`, with `ptr.store`/`ptr.load` and `builtin` integer arithmetic.
- New `--stage ast` and `--stage ir` driver stages.

## Notes
- `alloca` was added beyond the load/store/`p` originally listed: with a memory-based lowering there is no other source of pointers to load/store through, so it is the minimum needed to reach the goal.
- The 3 preprocessor snapshot updates are because `=` now lexes as a token instead of being silently dropped.
- Scope is kept to straight-line integer code: no control flow, no types beyond `int`/`void`.

All workspace tests pass (including new ptr-dialect roundtrip and codegen tests); the emitted IR round-trips through the IR parser.

https://claude.ai/code/session_01J9WaW4xYoP3qkESFShEXoa

---
_Generated by [Claude Code](https://claude.ai/code/session_01J9WaW4xYoP3qkESFShEXoa)_