### PR TITLE
Add mem2reg pass, memory interfaces, and `tir-opt` driver with tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "utils/filecheck",
     "utils/lit",
     "utils/not",
+    "utils/tir-opt",
     "tmdl",
     "xtask",
     "core",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,3 +8,10 @@ tir-macros = { path = "../utils/macros" }
 parking_lot = "0.12.3"
 thiserror = "2.0.12"
 ariadne = "0.3"
+
+[dev-dependencies]
+tir-lit = { path = "../utils/lit" }
+
+[[test]]
+name = "lit"
+harness = false

--- a/core/checks/Inputs/basic.tir
+++ b/core/checks/Inputs/basic.tir
@@ -1,0 +1,18 @@
+module {
+  func @f(%0: !i32, %1: !i32) -> !i32 {
+    %2 = ptr.alloca : !ptr.p<!i32>
+    ptr.store %0, %2
+    %3 = ptr.alloca : !ptr.p<!i32>
+    ptr.store %1, %3
+    %4 = ptr.alloca : !ptr.p<!i32>
+    %5 = ptr.load %2 : !i32
+    %6 = ptr.load %3 : !i32
+    %7 = muli %5, %6 : !i32
+    ptr.store %7, %4
+    %8 = ptr.load %4 : !i32
+    %9 = constant {value = 1} : !i32
+    %10 = addi %8, %9 : !i32
+    return %10
+  }
+  module_end
+}

--- a/core/checks/Mem2Reg/basic.tir
+++ b/core/checks/Mem2Reg/basic.tir
@@ -1,0 +1,11 @@
+// RUN: tir-opt --pass mem2reg %S/../Inputs/basic.tir | filecheck %s
+
+// CHECK: module {
+// CHECK-NEXT: func @f(%{{[0-9]+}}: !i32, %{{[0-9]+}}: !i32) -> !i32 {
+// CHECK-NEXT: %7 = muli %0, %1 : !i32
+// CHECK-NEXT: %9 = constant {value = 1} : !i32
+// CHECK-NEXT: %10 = addi %7, %9 : !i32
+// CHECK-NEXT: return %10
+// CHECK-NEXT: }
+// CHECK-NEXT: module_end
+// CHECK-NEXT: }

--- a/core/src/context.rs
+++ b/core/src/context.rs
@@ -294,6 +294,55 @@ impl Context {
         }
     }
 
+    /// Replace every SSA operand use of `old` with `new` across the live IR.
+    ///
+    /// This keeps the context-owned def-use lists in sync with the rewritten
+    /// operations. Register-attribute uses are intentionally left untouched: they
+    /// are not SSA operands and currently belong to machine IR, not high-level
+    /// scalar promotion.
+    pub fn replace_value_uses(&self, old: ValueId, new: ValueId) {
+        if old == new {
+            return;
+        }
+
+        let mut inner = self.0.write();
+        let uses = inner
+            .values
+            .get(&old)
+            .map(|v| v.uses().to_vec())
+            .unwrap_or_default();
+
+        for use_site in uses {
+            let crate::UseSite::Operand(index) = use_site.site() else {
+                continue;
+            };
+
+            let Some(op) = inner.operations.get(&use_site.op()).cloned() else {
+                continue;
+            };
+            if op.operands.get(index).copied() != Some(old) {
+                continue;
+            }
+
+            let mut new_instance = (*op).clone();
+            new_instance.operands[index] = new;
+            inner
+                .operations
+                .insert(use_site.op(), Arc::new(new_instance));
+
+            if let Some(old_value) = inner.values.get(&old).cloned() {
+                let mut old_value = (*old_value).clone();
+                old_value.remove_use(use_site.op(), use_site.site());
+                inner.values.insert(old, Arc::new(old_value));
+            }
+            if let Some(new_value) = inner.values.get(&new).cloned() {
+                let mut new_value = (*new_value).clone();
+                new_value.add_use(use_site.op(), use_site.site());
+                inner.values.insert(new, Arc::new(new_value));
+            }
+        }
+    }
+
     pub fn has_value(&self, id: ValueId) -> bool {
         self.0.read().values.contains_key(&id)
     }

--- a/core/src/dialects/ptr/mod.rs
+++ b/core/src/dialects/ptr/mod.rs
@@ -8,7 +8,10 @@ use std::any::Any;
 use std::sync::Arc;
 
 use crate::ty::TypeConstraint;
-use crate::{Context, Error, IRFormatter, Type, TypeId, dialect, operation, parse::Span};
+use crate::{
+    Context, Error, IRFormatter, MemoryRead, MemoryWrite, Operation, PromotableAllocation, Type,
+    TypeId, dialect, operation, parse::Span,
+};
 
 use crate as tir;
 use crate::Any as AnyConstraint;
@@ -120,6 +123,7 @@ operation! {
         results: R {
             result: "crate::ptr::PtrType",
         },
+        interfaces: [PromotableAllocation],
     }
 }
 
@@ -133,6 +137,7 @@ operation! {
         results: R {
             result: "AnyConstraint",
         },
+        interfaces: [MemoryRead],
     }
 }
 
@@ -144,6 +149,7 @@ operation! {
             value: "AnyConstraint",
             ptr: "crate::ptr::PtrType",
         },
+        interfaces: [MemoryWrite],
     }
 }
 
@@ -220,5 +226,31 @@ mod tests {
         let mut f = IRFormatter::new(&mut new_buf);
         new_func.print(&mut f).expect("print ok");
         assert_eq!(buf, new_buf);
+    }
+}
+
+impl PromotableAllocation for AllocaOp {
+    fn promoted_location(&self) -> tir::ValueId {
+        self.result()
+    }
+}
+
+impl MemoryRead for LoadOp {
+    fn read_location(&self) -> tir::ValueId {
+        self.operands()[0]
+    }
+
+    fn read_value(&self) -> tir::ValueId {
+        self.result()
+    }
+}
+
+impl MemoryWrite for StoreOp {
+    fn write_location(&self) -> tir::ValueId {
+        self.operands()[1]
+    }
+
+    fn written_value(&self) -> tir::ValueId {
+        self.operands()[0]
     }
 }

--- a/core/src/interfaces.rs
+++ b/core/src/interfaces.rs
@@ -1,4 +1,4 @@
-use crate::{Context, Operation};
+use crate::{Context, Operation, ValueId};
 
 pub trait Commutative {
     fn is_commutative(&self) -> bool {
@@ -50,6 +50,54 @@ pub trait SameOperandType {
             ));
         }
 
+        Ok(())
+    }
+}
+
+/// Identifies an operation that creates a memory location eligible for local SSA
+/// promotion. Implementations describe the location generically rather than tying
+/// mem2reg to a concrete pointer dialect.
+pub trait PromotableAllocation {
+    /// The SSA value that names the promotable memory location.
+    fn promoted_location(&self) -> ValueId;
+
+    fn verify_interface(
+        &self,
+        _this: &dyn Operation,
+        _context: &Context,
+    ) -> Result<(), crate::Error> {
+        Ok(())
+    }
+}
+
+/// Identifies an operation that reads a value from a memory location.
+pub trait MemoryRead {
+    /// The memory location being read.
+    fn read_location(&self) -> ValueId;
+    /// The SSA value produced by the read.
+    fn read_value(&self) -> ValueId;
+
+    fn verify_interface(
+        &self,
+        _this: &dyn Operation,
+        _context: &Context,
+    ) -> Result<(), crate::Error> {
+        Ok(())
+    }
+}
+
+/// Identifies an operation that writes a value to a memory location.
+pub trait MemoryWrite {
+    /// The memory location being written.
+    fn write_location(&self) -> ValueId;
+    /// The SSA value stored into the memory location.
+    fn written_value(&self) -> ValueId;
+
+    fn verify_interface(
+        &self,
+        _this: &dyn Operation,
+        _context: &Context,
+    ) -> Result<(), crate::Error> {
         Ok(())
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,6 +14,7 @@ mod ir_formatter;
 mod operand;
 mod operation;
 mod pass;
+pub mod passes;
 pub mod pbqp;
 mod region;
 pub mod sem_expr;
@@ -32,7 +33,9 @@ pub use context::{Context, ContextIterator, ContextRef, GetFromContext};
 pub use diagnostics::{print_error_range, print_parse_error};
 pub use dialect::Dialect;
 pub use error::Error;
-pub use interfaces::{Commutative, SameOperandType, Terminator};
+pub use interfaces::{
+    Commutative, MemoryRead, MemoryWrite, PromotableAllocation, SameOperandType, Terminator,
+};
 pub use ir_formatter::IRFormatter;
 pub use operand::Operand;
 pub use operation::{

--- a/core/src/passes/mem2reg.rs
+++ b/core/src/passes/mem2reg.rs
@@ -1,0 +1,175 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::Operation;
+use crate::{
+    Context, MemoryRead, MemoryWrite, OpId, OperationRef, Pass, PassError, PassTarget,
+    PromotableAllocation, Rewriter, ValueId, builtin::FuncOp,
+};
+
+#[derive(Default)]
+pub struct Mem2RegPass;
+
+#[derive(Default)]
+struct SlotState {
+    alloca: Option<OpId>,
+    current_value: Option<ValueId>,
+    replacements: Vec<(ValueId, ValueId)>,
+    erase_ops: BTreeSet<OpId>,
+    promotable: bool,
+}
+
+impl Mem2RegPass {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Pass for Mem2RegPass {
+    fn name(&self) -> &'static str {
+        "mem2reg"
+    }
+
+    fn target(&self) -> PassTarget {
+        PassTarget::Operation(FuncOp::name())
+    }
+
+    fn run(
+        &mut self,
+        op: &OperationRef,
+        context: &Context,
+        rewriter: &mut Rewriter,
+    ) -> Result<(), PassError> {
+        let Some(func) = op.as_op::<FuncOp>() else {
+            return Ok(());
+        };
+        let block = func.body();
+        let op_ids = block.op_ids();
+
+        let mut slots = BTreeMap::<ValueId, SlotState>::new();
+
+        for op_id in &op_ids {
+            let instance = context.get_op(*op_id);
+            if let Some(alloc) = instance.clone().as_interface::<dyn PromotableAllocation>() {
+                let location = alloc.promoted_location();
+                slots.insert(
+                    location,
+                    SlotState {
+                        alloca: Some(*op_id),
+                        current_value: None,
+                        replacements: Vec::new(),
+                        erase_ops: BTreeSet::new(),
+                        promotable: true,
+                    },
+                );
+            }
+        }
+
+        for op_id in &op_ids {
+            let instance = context.get_op(*op_id);
+            if instance
+                .clone()
+                .as_interface::<dyn PromotableAllocation>()
+                .is_some()
+            {
+                continue;
+            }
+
+            if let Some(read) = instance.clone().as_interface::<dyn MemoryRead>() {
+                let location = read.read_location();
+                if let Some(slot) = slots.get_mut(&location) {
+                    if let Some(value) = slot.current_value {
+                        slot.replacements.push((read.read_value(), value));
+                        slot.erase_ops.insert(*op_id);
+                    } else {
+                        slot.promotable = false;
+                    }
+                    continue;
+                }
+            }
+
+            if let Some(write) = instance.clone().as_interface::<dyn MemoryWrite>() {
+                let location = write.write_location();
+                if let Some(slot) = slots.get_mut(&location) {
+                    slot.current_value = Some(write.written_value());
+                    slot.erase_ops.insert(*op_id);
+                    continue;
+                }
+            }
+
+            for operand in &instance.operands {
+                if let Some(slot) = slots.get_mut(operand) {
+                    slot.promotable = false;
+                }
+            }
+        }
+
+        for slot in slots.values().filter(|slot| slot.promotable) {
+            for (old, new) in &slot.replacements {
+                context.replace_value_uses(*old, *new);
+            }
+        }
+
+        let mut erase_ops = BTreeSet::new();
+        for slot in slots.values().filter(|slot| slot.promotable) {
+            if let Some(alloca) = slot.alloca {
+                erase_ops.insert(alloca);
+            }
+            erase_ops.extend(slot.erase_ops.iter().copied());
+        }
+
+        for op_id in erase_ops {
+            if !context.has_operation(op_id) {
+                continue;
+            }
+            let target = OperationRef::new(context.get_op(op_id), Some(block.clone()), None);
+            rewriter.erase_op(&target)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        Context, IRBuilder, IRFormatter, Operation, PassManager,
+        builtin::{IntegerType, ops as b},
+        ptr::{PtrType, ops as p},
+    };
+
+    use super::Mem2RegPass;
+
+    #[test]
+    fn promotes_linear_stack_slot() {
+        let context = Context::with_default_dialects();
+        let i32_ty = IntegerType::new(&context, 32);
+        let param = context.create_value(i32_ty, None);
+        let param_id = param.id();
+        let region = context.create_region();
+        let block = context.create_block(vec![param]);
+        region.add_block(block.id());
+        let func = b::func(&context, "id", i32_ty, Some(region.id())).build();
+
+        let mut builder = IRBuilder::new(func.body());
+        let slot = builder.insert(p::alloca(&context, PtrType::typed(&context, i32_ty)).build());
+        builder.insert(p::store(&context, param_id, slot.result()).build());
+        let loaded = builder
+            .insert(p::load(&context, slot.result(), i32_ty).build())
+            .result();
+        builder.insert(b::r#return(&context, loaded).build());
+
+        let mut pm = PassManager::new();
+        pm.add_pass(Mem2RegPass::new());
+        pm.run(&context, context.get_op(func.id()))
+            .expect("mem2reg");
+
+        let mut out = String::new();
+        let mut fmt = IRFormatter::new(&mut out);
+        func.print(&mut fmt).expect("print");
+
+        assert!(!out.contains("ptr.alloca"));
+        assert!(!out.contains("ptr.store"));
+        assert!(!out.contains("ptr.load"));
+        assert!(out.contains(&format!("return %{}", param_id.number())));
+    }
+}

--- a/core/src/passes/mod.rs
+++ b/core/src/passes/mod.rs
@@ -1,0 +1,5 @@
+//! Transformation passes over generic TIR interfaces.
+
+pub mod mem2reg;
+
+pub use mem2reg::Mem2RegPass;

--- a/core/src/value.rs
+++ b/core/src/value.rs
@@ -78,6 +78,12 @@ impl Value {
     pub(crate) fn remove_uses_of(&mut self, op: OpId) {
         self.uses.retain(|u| u.op != op);
     }
+
+    pub(crate) fn remove_use(&mut self, op: OpId, site: UseSite) {
+        if let Some(index) = self.uses.iter().position(|u| u.op == op && u.site == site) {
+            self.uses.remove(index);
+        }
+    }
 }
 
 /// Where a [`Use`] sits within the referencing operation.

--- a/core/tests/lit.rs
+++ b/core/tests/lit.rs
@@ -1,0 +1,43 @@
+//! LIT-style FileCheck tests for core IR passes.
+//!
+//! The tests live with `tir` because they exercise core-library transforms. RUN
+//! lines still invoke the `tir-opt` utility so the command-line pass plumbing is
+//! covered without making `utils/tir-opt` own core pass test fixtures.
+
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    let tir_opt = cargo_tir_opt_wrapper();
+    let tir_opt = tir_opt
+        .to_str()
+        .expect("tir-opt wrapper path must be valid UTF-8");
+
+    tir_lit::harness_main(
+        env!("CARGO_MANIFEST_DIR"),
+        "checks",
+        &[("tir-opt", tir_opt)],
+    );
+}
+
+fn cargo_tir_opt_wrapper() -> PathBuf {
+    let mut path = std::env::current_exe().expect("current test executable path");
+    path.pop();
+    path.push("tir-opt-wrapper.sh");
+
+    let mut file = std::fs::File::create(&path).expect("create tir-opt wrapper");
+    writeln!(file, "#!/usr/bin/env bash").expect("write wrapper shebang");
+    writeln!(file, "exec cargo run -q -p tir-opt -- \"$@\"").expect("write wrapper body");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(&path)
+            .expect("wrapper metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&path, permissions).expect("make wrapper executable");
+    }
+
+    path
+}

--- a/utils/tir-opt/Cargo.toml
+++ b/utils/tir-opt/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tir-opt"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+tir = { path = "../../core" }
+clap = { version = "4.6.0", features = ["derive"] }
+
+[[bin]]
+name = "tir-opt"
+path = "src/main.rs"
+

--- a/utils/tir-opt/src/main.rs
+++ b/utils/tir-opt/src/main.rs
@@ -1,0 +1,87 @@
+use std::ffi::OsString;
+use std::fs::File;
+use std::io::{self, Read, Write};
+
+use clap::Parser;
+use tir::{Context, IRFormatter, Operation, PassManager, builtin::ModuleOp, passes::Mem2RegPass};
+
+#[derive(Debug, Parser)]
+#[command(name = "tir-opt")]
+struct Cli {
+    /// Pass to run. May be repeated; currently supports `mem2reg`.
+    #[arg(long = "pass", short = 'p')]
+    passes: Vec<String>,
+
+    /// Output file, or `-` for stdout.
+    #[arg(short = 'o', default_value = "-")]
+    output: OsString,
+
+    /// Input IR file, or `-`/omitted for stdin.
+    input: Option<OsString>,
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("tir-opt: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let cli = Cli::parse();
+    let input = read_input(cli.input.as_ref())?;
+
+    let context = Context::with_default_dialects();
+    let module = tir::parse::ir::parse_ir::<ModuleOp>(&context, &input)
+        .map_err(|(span, err)| format!("failed to parse input at byte {}: {err:?}", span.0))?;
+
+    let mut pm = PassManager::new();
+    for pass in &cli.passes {
+        match pass.as_str() {
+            "mem2reg" => {
+                pm.add_pass(Mem2RegPass::new());
+            }
+            other => return Err(format!("unknown pass '{other}'")),
+        }
+    }
+
+    pm.run(&context, context.get_op(module.id()))
+        .map_err(|e| format!("pass pipeline failed: {e}"))?;
+
+    let mut rendered = String::new();
+    let mut fmt = IRFormatter::new(&mut rendered);
+    module
+        .print(&mut fmt)
+        .map_err(|e| format!("failed to print IR: {e}"))?;
+
+    write_output(cli.output.as_os_str(), &rendered)
+}
+
+fn read_input(path: Option<&OsString>) -> Result<String, String> {
+    let mut input = String::new();
+    match path {
+        None => io::stdin()
+            .read_to_string(&mut input)
+            .map_err(|e| format!("failed to read stdin: {e}"))?,
+        Some(path) if path == "-" => io::stdin()
+            .read_to_string(&mut input)
+            .map_err(|e| format!("failed to read stdin: {e}"))?,
+        Some(path) => File::open(path)
+            .map_err(|e| format!("failed to open '{}': {e}", path.to_string_lossy()))?
+            .read_to_string(&mut input)
+            .map_err(|e| format!("failed to read '{}': {e}", path.to_string_lossy()))?,
+    };
+    Ok(input)
+}
+
+fn write_output(path: &std::ffi::OsStr, contents: &str) -> Result<(), String> {
+    if path == "-" {
+        print!("{contents}");
+        io::stdout()
+            .flush()
+            .map_err(|e| format!("failed to flush stdout: {e}"))
+    } else {
+        std::fs::write(path, contents)
+            .map_err(|e| format!("failed to write '{}': {e}", path.to_string_lossy()))
+    }
+}


### PR DESCRIPTION
### Motivation

- Implement local SSA promotion (mem2reg) for core TIR using generic memory interfaces so the transform is dialect-agnostic. 
- Provide a small `tir-opt` CLI to run passes end-to-end and add a LIT-style harness to exercise pass tests with `FileCheck`.

### Description

- Introduce `PromotableAllocation`, `MemoryRead`, and `MemoryWrite` interfaces in `core::interfaces` and export them from the crate via `lib.rs`.
- Add `Context::replace_value_uses` and `Value::remove_use` to update def/use lists when operands are rewritten.
- Implement the new interfaces for the `ptr` dialect (`AllocaOp`, `LoadOp`, `StoreOp`) in `core/src/dialects/ptr/mod.rs`.
- Implement the `mem2reg` pass in `core/src/passes/mem2reg.rs` and expose it via `core/src/passes/mod.rs`.
- Add a new `tir-opt` utility (`utils/tir-opt`) that parses IR, runs selected passes (currently `mem2reg`), and prints the transformed IR.
- Add a LIT-style test harness (`core/tests/lit.rs`), test fixtures (`core/checks/*`), and a basic unit test for the `mem2reg` pass.
- Update workspace `Cargo.toml` to include `utils/tir-opt` and add a dev-test entry for `lit` in `core/Cargo.toml`.

### Testing

- Ran `cargo test` for the workspace and the `tir`/`core` package; unit tests including the `mem2reg` unit test succeeded.
- Exercised the pass end-to-end via the LIT harness test (`core/tests/lit.rs`) and the `core/checks` FileCheck fixtures using the `tir-opt` wrapper, and those checks passed under the test run.
- Verified parsing/printing roundtrip for `ptr` pointer tests and that IR produced by the pass no longer contains the promoted `ptr.alloca`/`ptr.store`/`ptr.load` sequences in the unit test output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd2deb9f88328ac9f0d9883e24dbf)