### PR TITLE
Add --march/--mcpu parsing for RISC-V and AArch64 and wire into target selection

### DIFF
--- a/backends/arm64/src/lib.rs
+++ b/backends/arm64/src/lib.rs
@@ -3,6 +3,55 @@ use tir::{Any, Operation};
 
 include!(concat!(env!("OUT_DIR"), "/arm64.rs"));
 
+/// Parsed AArch64 target selection from `--march`/`--mcpu`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TargetConfig;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CpuModel {
+    Generic,
+    InOrder,
+    OutOfOrder,
+}
+
+impl TargetConfig {
+    /// Parse an AArch64 `--march`/`--mcpu` pair.
+    pub fn parse(march: &str, mcpu: Option<&str>) -> Option<Self> {
+        parse_march(march)?;
+        if let Some(mcpu) = mcpu {
+            parse_mcpu(mcpu)?;
+        }
+        Some(TargetConfig)
+    }
+
+    /// Canonical architecture name for diagnostics and target-specific behavior.
+    pub fn canonical_name(&self) -> &'static str {
+        "arm64"
+    }
+}
+
+fn parse_march(march: &str) -> Option<()> {
+    match normalize(march).as_str() {
+        "arm64" | "aarch64" | "armv8" | "armv8a" | "armv8-a" => Some(()),
+        _ => None,
+    }
+}
+
+fn parse_mcpu(mcpu: &str) -> Option<CpuModel> {
+    match normalize(mcpu).as_str() {
+        "generic" | "generic-arm64" | "generic-aarch64" => Some(CpuModel::Generic),
+        "generic-in-order" | "generic-inorder" | "in-order" | "inorder" => Some(CpuModel::InOrder),
+        "generic-ooo" | "generic-out-of-order" | "ooo" | "out-of-order" => {
+            Some(CpuModel::OutOfOrder)
+        }
+        _ => None,
+    }
+}
+
+fn normalize(s: &str) -> String {
+    s.trim().to_ascii_lowercase().replace('_', "-")
+}
+
 operation! {
     VirtualReturnOp {
         name: "vret",
@@ -575,5 +624,25 @@ mod tests {
             Some(&"sub_imm"),
             "the frame prologue (sub fp) should lead the block, got {names:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod target_parser_tests {
+    use super::TargetConfig;
+
+    #[test]
+    fn accepts_arm64_aliases_and_generic_cpus() {
+        assert_eq!(
+            TargetConfig::parse("aarch64", Some("generic-in-order")).map(|c| c.canonical_name()),
+            Some("arm64")
+        );
+        assert!(TargetConfig::parse("armv8-a", Some("generic-aarch64")).is_some());
+    }
+
+    #[test]
+    fn rejects_unknown_march_or_cpu() {
+        assert!(TargetConfig::parse("rv64im", None).is_none());
+        assert!(TargetConfig::parse("arm64", Some("cortex-a710")).is_none());
     }
 }

--- a/backends/riscv/src/lib.rs
+++ b/backends/riscv/src/lib.rs
@@ -3,6 +3,155 @@ use tir::{Any, Operation};
 
 include!(concat!(env!("OUT_DIR"), "/riscv.rs"));
 
+/// Parsed RISC-V target selection from `--march`/`--mcpu`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TargetConfig {
+    xlen: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CpuModel {
+    Generic,
+    InOrder,
+    OutOfOrder,
+}
+
+impl TargetConfig {
+    /// Parse a RISC-V `--march`/`--mcpu` pair.
+    pub fn parse(march: &str, mcpu: Option<&str>) -> Option<Self> {
+        let config = parse_march(march)?;
+        if let Some(mcpu) = mcpu {
+            parse_mcpu(mcpu, config)?;
+        }
+        Some(config)
+    }
+
+    /// Canonical architecture name for diagnostics and target-specific behavior.
+    pub fn canonical_name(&self) -> &'static str {
+        match self.xlen {
+            32 => "riscv32",
+            _ => "riscv64",
+        }
+    }
+}
+
+fn parse_march(march: &str) -> Option<TargetConfig> {
+    let march = normalize(march);
+    match march.as_str() {
+        "riscv" => Some(TargetConfig { xlen: 64 }),
+        "riscv32" => Some(TargetConfig { xlen: 32 }),
+        "riscv64" => Some(TargetConfig { xlen: 64 }),
+        _ => parse_riscv_isa_string(&march),
+    }
+}
+
+fn parse_mcpu(mcpu: &str, march_config: TargetConfig) -> Option<CpuModel> {
+    let mcpu = normalize(mcpu);
+    for (prefix, xlen) in [("riscv32-", 32), ("riscv64-", 64)] {
+        if let Some(model) = mcpu.strip_prefix(prefix).and_then(parse_cpu_model) {
+            return (march_config.xlen == xlen).then_some(model);
+        }
+    }
+
+    parse_cpu_model(&mcpu)
+}
+
+fn parse_cpu_model(name: &str) -> Option<CpuModel> {
+    match name {
+        "generic" => Some(CpuModel::Generic),
+        "generic-in-order" | "generic-inorder" | "in-order" | "inorder" => Some(CpuModel::InOrder),
+        "generic-ooo" | "generic-out-of-order" | "ooo" | "out-of-order" => {
+            Some(CpuModel::OutOfOrder)
+        }
+        _ => None,
+    }
+}
+
+fn normalize(s: &str) -> String {
+    s.trim().to_ascii_lowercase().replace('_', "-")
+}
+
+fn parse_riscv_isa_string(march: &str) -> Option<TargetConfig> {
+    let rest = march.strip_prefix("rv")?;
+    let (xlen, rest) = if let Some(rest) = rest.strip_prefix("32") {
+        (32, rest)
+    } else if let Some(rest) = rest.strip_prefix("64") {
+        (64, rest)
+    } else {
+        return None;
+    };
+
+    let mut chars = rest.chars().peekable();
+    let base = chars.next()?;
+    match base {
+        'i' | 'e' | 'g' => skip_extension_version(&mut chars),
+        _ => return None,
+    }
+
+    while chars.peek().is_some() {
+        if chars.peek() == Some(&'-') {
+            chars.next();
+            if chars.peek().is_none() {
+                return None;
+            }
+            continue;
+        }
+
+        let ext = chars.next()?;
+        if ext.is_ascii_digit() {
+            return None;
+        }
+
+        match ext {
+            'm' | 'a' | 'f' | 'd' | 'q' | 'l' | 'c' | 'b' | 'j' | 't' | 'p' | 'v' | 'h' => {
+                skip_extension_version(&mut chars);
+            }
+            'z' | 's' | 'x' => {
+                if !consume_multi_letter_extension(&mut chars) {
+                    return None;
+                }
+            }
+            _ => return None,
+        }
+    }
+
+    Some(TargetConfig { xlen })
+}
+
+fn consume_multi_letter_extension<I>(chars: &mut std::iter::Peekable<I>) -> bool
+where
+    I: Iterator<Item = char>,
+{
+    let mut consumed_name_char = false;
+    while let Some(&c) = chars.peek() {
+        if c == '-' {
+            break;
+        }
+        if c.is_ascii_lowercase() || c.is_ascii_digit() {
+            consumed_name_char = true;
+            chars.next();
+        } else {
+            return false;
+        }
+    }
+    consumed_name_char
+}
+
+fn skip_extension_version<I>(chars: &mut std::iter::Peekable<I>)
+where
+    I: Iterator<Item = char>,
+{
+    while chars.peek().is_some_and(|c| c.is_ascii_digit()) {
+        chars.next();
+    }
+    if chars.peek() == Some(&'p') {
+        chars.next();
+        while chars.peek().is_some_and(|c| c.is_ascii_digit()) {
+            chars.next();
+        }
+    }
+}
+
 operation! {
     VirtualReturnOp {
         name: "vret",
@@ -994,5 +1143,41 @@ mod tests {
             Some(&"addi"),
             "the frame prologue (addi sp) should lead the block, got {names:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod target_parser_tests {
+    use super::TargetConfig;
+
+    #[test]
+    fn march_accepts_gcc_style_isa_strings() {
+        assert_eq!(
+            TargetConfig::parse("rv64im", None).map(|c| c.canonical_name()),
+            Some("riscv64")
+        );
+        assert_eq!(
+            TargetConfig::parse("rv32imac", None).map(|c| c.canonical_name()),
+            Some("riscv32")
+        );
+        assert_eq!(
+            TargetConfig::parse("rv64gc_zba_zbb", None).map(|c| c.canonical_name()),
+            Some("riscv64")
+        );
+    }
+
+    #[test]
+    fn mcpu_accepts_target_prefixed_generic_names() {
+        assert!(TargetConfig::parse("rv32im", Some("riscv32-generic-in-order")).is_some());
+        assert!(TargetConfig::parse("rv64im", Some("riscv32-generic-in-order")).is_none());
+        assert!(TargetConfig::parse("rv64im", Some("generic-in-order")).is_some());
+    }
+
+    #[test]
+    fn unknown_or_malformed_march_is_rejected() {
+        assert!(TargetConfig::parse("rv64", None).is_none());
+        assert!(TargetConfig::parse("rv64zm", None).is_none());
+        assert!(TargetConfig::parse("mips", None).is_none());
+        assert!(TargetConfig::parse("rv64im", Some("riscv64-unknown-cpu")).is_none());
     }
 }

--- a/backends/targets/checks/target-parsers.tir
+++ b/backends/targets/checks/target-parsers.tir
@@ -1,0 +1,12 @@
+// RUN: tir-mc --march=rv64im --mcpu=riscv64-generic-in-order --run=isel %s | filecheck %s
+// RUN: tir-mc --march=rv32im --mcpu=riscv32-generic-in-order --run=isel %s | filecheck %s
+// RUN: not tir-mc --march=rv64im --mcpu=riscv32-generic-in-order --run=isel %s
+
+// CHECK: riscv.add
+module {
+  func @add(%0: !i32, %1: !i32) -> !i32 {
+    %2 = addi %0, %1 : !i32
+    return %2
+  }
+  module_end
+}

--- a/backends/targets/src/lib.rs
+++ b/backends/targets/src/lib.rs
@@ -1,9 +1,9 @@
 //! Target registry shared by `tir-mc` and `isasim`.
 //!
-//! [`select`] maps a `--march` (and optional `--mcpu`) string onto a concrete
-//! [`TargetMachine`]. Both the codegen driver and the simulator go through this
-//! one entry point, so the set of supported targets — and the spelling of their
-//! names — is defined in a single place.
+//! [`select`] asks each backend to parse the requested `--march`/`--mcpu` pair
+//! and wraps the first backend that accepts it as a concrete [`TargetMachine`].
+//! Backend-specific spelling rules stay in the backend crates instead of being
+//! duplicated in this registry.
 
 use tir::Context;
 use tir_be_common::AsmDialect;
@@ -16,28 +16,31 @@ use tir_be_common::sched::MachineModel;
 use arm64::Arm64Dialect;
 use tir_riscv::RiscvDialect;
 
-/// Resolve a `--march`/`--mcpu` pair to a target, or `None` if unknown.
-///
-/// `mcpu` is accepted for forward compatibility (sub-architecture / scheduling
-/// model selection) but does not yet influence the choice of backend.
-pub fn select(march: &str, _mcpu: Option<&str>) -> Option<Box<dyn TargetMachine>> {
-    match march.to_ascii_lowercase().as_str() {
-        "riscv" | "riscv64" | "rv64" | "rv64gc" | "rv64i" => Some(Box::new(RiscvTarget)),
-        "arm64" | "aarch64" | "armv8" | "armv8a" => Some(Box::new(Arm64Target)),
-        _ => None,
+/// Resolve a `--march`/`--mcpu` pair to a target, or `None` if no backend accepts it.
+pub fn select(march: &str, mcpu: Option<&str>) -> Option<Box<dyn TargetMachine>> {
+    if let Some(config) = tir_riscv::TargetConfig::parse(march, mcpu) {
+        return Some(Box::new(RiscvTarget { config }));
     }
+
+    if let Some(config) = arm64::TargetConfig::parse(march, mcpu) {
+        return Some(Box::new(Arm64Target { config }));
+    }
+
+    None
 }
 
-/// Names accepted by [`select`], one canonical spelling per target, for help
-/// text and error messages.
-pub const SUPPORTED_TARGETS: &[&str] = &["riscv64", "arm64"];
+/// Names accepted by [`select`], one canonical spelling per target family, for
+/// help text and error messages.
+pub const SUPPORTED_TARGETS: &[&str] = &["riscv32", "riscv64", "arm64"];
 
-/// The RISC-V (RV64I) target.
-pub struct RiscvTarget;
+/// The RISC-V target.
+pub struct RiscvTarget {
+    config: tir_riscv::TargetConfig,
+}
 
 impl TargetMachine for RiscvTarget {
     fn name(&self) -> &'static str {
-        "riscv64"
+        self.config.canonical_name()
     }
 
     fn register_dialects(&self, context: &Context) {
@@ -74,11 +77,13 @@ impl TargetMachine for RiscvTarget {
 }
 
 /// The AArch64 (ARMv8-A) target.
-pub struct Arm64Target;
+pub struct Arm64Target {
+    config: arm64::TargetConfig,
+}
 
 impl TargetMachine for Arm64Target {
     fn name(&self) -> &'static str {
-        "arm64"
+        self.config.canonical_name()
     }
 
     fn register_dialects(&self, context: &Context) {


### PR DESCRIPTION
### Motivation
- Move `--march`/`--mcpu` parsing into each backend so spelling rules and ISA grammar live with the backend implementation. 
- Allow backends to accept or reject `--march`/`--mcpu` pairs and produce a canonical target name and configuration for downstream selection. 
- Add tests and a TIR check to validate accepted/rejected ISA strings and generic `mcpu` forms. 

### Description
- Introduce `TargetConfig` and `CpuModel` types in `backends/riscv` and `backends/arm64`, with `parse` and `canonical_name` APIs and shared `normalize` helper. 
- Implement RISC-V ISA string parsing (`parse_riscv_isa_string`) that understands `rv32/rv64` prefixes, standard extensions, multi-letter extensions, and version suffixes. 
- Implement AArch64 `--march`/`--mcpu` parsing that accepts common aliases and generic CPU model names. 
- Update `backends/targets::select` to ask each backend to parse the `--march`/`--mcpu` pair and construct `RiscvTarget` and `Arm64Target` with the parsed `TargetConfig`. 
- Update `SUPPORTED_TARGETS` to include canonical RISC-V spellings and change `RiscvTarget`/`Arm64Target` to return names via the backend `canonical_name`. 
- Add unit tests under `backends/riscv` and `backends/arm64` for the new parsers and add a TIR check file `backends/targets/checks/target-parsers.tir` to exercise selection in a lit-style check. 

### Testing
- Ran `cargo test` for the workspace and all unit tests including the new `target_parser_tests` in `backends/riscv` and `backends/arm64` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a226502d2f88328868a53b490f6897e)