### PR TITLE
fix: correct APInt two's complement negation

### DIFF
--- a/core/src/utils/apint.rs
+++ b/core/src/utils/apint.rs
@@ -494,7 +494,7 @@ impl APInt {
         APInt {
             width: self.width,
             signed: self.signed,
-            value: (!(self.value).wrapping_add(1)) & mask,
+            value: (!self.value).wrapping_add(1) & mask,
         }
     }
 
@@ -921,6 +921,24 @@ mod tests {
 
         assert_eq!(low.to_u64(), 0x2468ACF13579BDE0);
         assert_eq!(high.to_u64(), 0); // No overflow for this multiplication
+    }
+
+    #[test]
+    fn test_neg() {
+        let one = APInt::new_signed(8, 1);
+        assert_eq!(one.neg().to_i64(), -1);
+
+        let minus_one = APInt::new_signed(8, -1);
+        assert_eq!(minus_one.neg().to_i64(), 1);
+
+        let zero = APInt::new_signed(8, 0);
+        assert_eq!(zero.neg().to_i64(), 0);
+    }
+
+    #[test]
+    fn test_abs() {
+        assert_eq!(APInt::new_signed(8, -5).abs().to_i64(), 5);
+        assert_eq!(APInt::new_signed(8, 5).abs().to_i64(), 5);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- `APInt::neg` computed two's complement incorrectly due to operator precedence, producing wrong negation for signed values.
- Add regression tests to prevent this class of regression and cover `neg` and `abs` behavior for positive, negative, and zero values.

### Description
- Fix `APInt::neg` implementation by computing `(!self.value).wrapping_add(1) & mask` instead of `(!(self.value).wrapping_add(1)) & mask`.
- Add unit tests `test_neg` and `test_abs` in `core/src/utils/apint.rs` to validate signed negation and absolute value.
- Run formatting and lints as part of the change.

### Testing
- Ran `cargo fmt --check` which succeeded.
- Ran `cargo test -p tir test_neg` which passed.
- Ran `cargo test -p tir test_abs` which passed.
- Ran the full `cargo test -p tir` suite which passed (all tests green).
- Ran `cargo clippy -p tir -- -D warnings` which passed with no warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22778d4c48832886918c662dd1a195)