### PR TITLE
fix(filecheck): honor CHECK-NOT before line directives

### DIFF
--- a/utils/filecheck/src/matcher.rs
+++ b/utils/filecheck/src/matcher.rs
@@ -204,6 +204,7 @@ impl<'a> Matcher<'a> {
         let next_end = self.line_end(next_start);
         match self.search(&compiled, next_start, next_end) {
             Some((range, vars)) => {
+                self.check_nots(self.pos, range.start)?;
                 self.commit(range, vars);
                 Ok(())
             }
@@ -221,6 +222,7 @@ impl<'a> Matcher<'a> {
         let line_end = self.line_end(self.pos);
         match self.search(&compiled, self.pos, line_end) {
             Some((range, vars)) => {
+                self.check_nots(self.pos, range.start)?;
                 self.commit(range, vars);
                 Ok(())
             }
@@ -244,6 +246,7 @@ impl<'a> Matcher<'a> {
         let next_start = line_end + 1;
         let next_end = self.line_end(next_start);
         if next_start == next_end {
+            self.check_nots(self.pos, next_start)?;
             self.pos = next_start;
             Ok(())
         } else {
@@ -430,6 +433,27 @@ mod tests {
     fn check_same() {
         let input = "foo bar baz\n";
         assert!(check(input, "// CHECK: foo\n// CHECK-SAME: baz\n").is_ok());
+    }
+
+    #[test]
+    fn check_not_applies_before_next_same_and_empty() {
+        assert!(check(
+            "foo bad bar\n",
+            "// CHECK: foo\n// CHECK-NOT: bad\n// CHECK-SAME: bar\n"
+        )
+        .is_err());
+
+        assert!(check(
+            "foo\nbad ok\n",
+            "// CHECK: foo\n// CHECK-NOT: bad\n// CHECK-NEXT: ok\n"
+        )
+        .is_err());
+
+        assert!(check(
+            "foo bad\n\n",
+            "// CHECK: foo\n// CHECK-NOT: bad\n// CHECK-EMPTY:\n"
+        )
+        .is_err());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- FileCheck allowed pending `CHECK-NOT` patterns to be ignored when matching `CHECK-NEXT`, `CHECK-SAME`, and `CHECK-EMPTY`, which could let forbidden text appear immediately before line-directed matches.

### Description
- Call `self.check_nots(self.pos, range.start)?` before committing matches in `match_next` and `match_same` in `utils/filecheck/src/matcher.rs`.
- Call `self.check_nots(self.pos, next_start)?` before accepting an empty line in `match_empty` in `utils/filecheck/src/matcher.rs`.
- Add regression test `check_not_applies_before_next_same_and_empty` to cover forbidden text before `CHECK-SAME`, `CHECK-NEXT`, and `CHECK-EMPTY`.
- Commit message: `fix(filecheck): honor CHECK-NOT before line directives`.

### Testing
- Ran `cargo test -p filecheck check_not_applies_before_next_same_and_empty` and it passed.
- Ran `cargo test -p filecheck` and the `filecheck` unit test suite passed (`18 passed`).
- Ran `cargo clippy -p filecheck -- -D warnings` with no warnings reported.
- A full repository `cargo test` run was started but large lit tests required manual intervention; the change is limited to `filecheck` and verified by its unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22800977c8832899f1432d2d04df4f)